### PR TITLE
Render headers as head2man rather than bold text

### DIFF
--- a/lib/Pod/To/Man.pm6
+++ b/lib/Pod/To/Man.pm6
@@ -4,13 +4,21 @@ sub escape($s) {
     $s.subst(:g, /\-/, Q'\-');
 }
 
-sub head2man($heading) {
+sub head2man($heading, :$level) {
 
-    qq[.SH "{$heading.uc.&escape}"\n]
+    my $type = 'SH';
+    if $level > 1
+    {
+        $type = 'SS';
+    }
+
+    qq[.$type "{$heading.uc.&escape}"\n]
 }
 
 multi sub pod2man(Pod::Heading $pod) {
-    "\\fB" ~ $pod.contents>>.&pod2man.join ~ "\\fR";
+    return head2man($pod.contents>>.&pod2man.join,
+        level => $pod.level
+    );
 }
 multi sub pod2man(Pod::Block::Named $pod) {
     given $pod.name {


### PR DESCRIPTION
In the old version, the following would break (NEW_SECTION would be indented like it was a part of the =defn):

=head1 SECTION

=defn Something
Something

=head1 NEW_SECTION